### PR TITLE
Changing wrong previous session error

### DIFF
--- a/server/https.go
+++ b/server/https.go
@@ -162,7 +162,7 @@ func (s *server) enumerate() ([]entry, error) {
 }
 
 var (
-	ErrSessionNotFound = errors.New("session not found")
+	ErrSessionNotFound = errors.New("wrong previous session")
 	ErrMalformedData   = errors.New("malformed data")
 )
 


### PR DESCRIPTION
This error string is hard-coded in trezor.js; this is needed for multitasking to work without changes.