### PR TITLE
Adding locks

### DIFF
--- a/server/https.go
+++ b/server/https.go
@@ -14,6 +14,7 @@ import (
 	"reflect"
 	"regexp"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/jpochyla/trezord-go/usb"
@@ -33,6 +34,13 @@ type server struct {
 	https    *http.Server
 	bus      *usb.USB
 	sessions map[string]*session
+
+	sessionsMutex sync.Mutex
+
+	callMutex      sync.Mutex
+	callInProgress bool
+
+	lastInfos []usb.Info
 }
 
 func New(bus *usb.USB) (*server, error) {
@@ -48,9 +56,11 @@ func New(bus *usb.USB) (*server, error) {
 		TLSConfig: config,
 	}
 	s := &server{
-		bus:      bus,
-		https:    https,
-		sessions: make(map[string]*session),
+		bus:            bus,
+		https:          https,
+		sessions:       make(map[string]*session),
+		callInProgress: false,
+		lastInfos:      make([]usb.Info, 0),
 	}
 	r := mux.NewRouter()
 
@@ -194,10 +204,22 @@ func (s *server) Enumerate(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *server) enumerate() ([]entry, error) {
-	infos, err := s.bus.Enumerate()
-	if err != nil {
-		return nil, err
+	s.sessionsMutex.Lock()
+	defer s.sessionsMutex.Unlock()
+	s.callMutex.Lock()
+	defer s.callMutex.Unlock()
+
+	infos := s.lastInfos
+
+	if !s.callInProgress {
+		busInfos, err := s.bus.Enumerate()
+		if err != nil {
+			return nil, err
+		}
+		infos = busInfos
+		s.lastInfos = infos
 	}
+
 	entries := make([]entry, 0, len(infos))
 	for _, info := range infos {
 		e := entry{
@@ -224,6 +246,9 @@ var (
 )
 
 func (s *server) Acquire(w http.ResponseWriter, r *http.Request) {
+	s.sessionsMutex.Lock()
+	defer s.sessionsMutex.Unlock()
+
 	vars := mux.Vars(r)
 	path := vars["path"]
 	prev := vars["session"]
@@ -301,6 +326,9 @@ func (s *server) release(session string) error {
 }
 
 func (s *server) Release(w http.ResponseWriter, r *http.Request) {
+	s.sessionsMutex.Lock()
+	defer s.sessionsMutex.Unlock()
+
 	vars := mux.Vars(r)
 	session := vars["session"]
 
@@ -321,10 +349,23 @@ func (s *server) Call(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	s.callMutex.Lock()
+	s.callInProgress = true
+	s.callMutex.Unlock()
+
+	defer func() {
+		s.callMutex.Lock()
+		s.callInProgress = false
+		s.callMutex.Unlock()
+	}()
+
 	vars := mux.Vars(r)
 	session := vars["session"]
 
+	s.sessionsMutex.Lock()
 	acquired, _ := s.sessions[session]
+	s.sessionsMutex.Unlock()
+
 	if acquired == nil {
 		respondError(w, ErrSessionNotFound)
 		return


### PR DESCRIPTION
There are two locks, because there are two different kind of mutual exclusivity.

First deals with sessions - we want access to sessions to be atomic.

Second deals with enumerating and call - because of some underlying issues on some OSes, we cannot make calls and enumeration at the same time.

*However*, while doing call, we can reasonably assume that the enumeration returns similar values to previous enumeration. So, instead of blocking enumerate on call, we just set that call is hapenning and we use the previous USB info.