### PR TITLE
Close device on closed http request

### DIFF
--- a/server/https.go
+++ b/server/https.go
@@ -245,6 +245,12 @@ func (s *server) Release(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *server) Call(w http.ResponseWriter, r *http.Request) {
+	cn, ok := w.(http.CloseNotifier)
+	if !ok {
+		http.Error(w, "cannot stream", http.StatusInternalServerError)
+		return
+	}
+
 	vars := mux.Vars(r)
 	session := vars["session"]
 
@@ -253,6 +259,20 @@ func (s *server) Call(w http.ResponseWriter, r *http.Request) {
 		respondError(w, ErrSessionNotFound)
 		return
 	}
+
+	finished := make(chan bool)
+	defer func() {
+		finished <- true
+	}()
+
+	go func() {
+		select {
+		case <-finished:
+			return
+		case <-cn.CloseNotify():
+			s.release(session)
+		}
+	}()
 
 	msg, err := decodeRaw(r.Body)
 	if err != nil {


### PR DESCRIPTION
I think this solution is cleaner and more readable than the solution we talked about.

Closing the device ends the read (or write). Also we release and close the device, so it is in cleaner state.

(Note that there is a conflict with https://github.com/jpochyla/trezord-go/pull/11, but it's easy to fix)