### PR TITLE
Remove enumerate in listen with empty request

### DIFF
--- a/server/https.go
+++ b/server/https.go
@@ -107,15 +107,6 @@ func (s *server) Listen(w http.ResponseWriter, r *http.Request) {
 
 	json.NewDecoder(r.Body).Decode(entries)
 
-	if entries == nil {
-		e, err := s.enumerate()
-		if err != nil {
-			respondError(w, err)
-			return
-		}
-		entries = e
-	}
-
 	for i := 0; i < iterMax; i++ {
 		e, err := s.enumerate()
 		if err != nil {


### PR DESCRIPTION
This has been included in the previous version for backwards compatibility; we don't need that anymore.

Listen should always have a body with previous enumeration result.