### PR TITLE
Using a copy of sessionId in enumerate

### DIFF
--- a/server/https.go
+++ b/server/https.go
@@ -155,7 +155,10 @@ func (s *server) enumerate() ([]entry, error) {
 		}
 		for _, ss := range s.sessions {
 			if ss.path == info.Path {
-				e.Session = &ss.id
+				// copying to prevent overwriting on acquire
+				// and wrong comparison in Listen
+				ssIdCopy := ss.id
+				e.Session = &ssIdCopy
 			}
 		}
 		entries = append(entries, e)


### PR DESCRIPTION
Without this fix, when session ID is changed (on session "stealing"), the string with the ID gets rewritten and `reflect.DeepEqual(entries, e)` returns true, even when it shouldn't