### PR TITLE
Try opening 3 times with delay

### DIFF
--- a/server/https.go
+++ b/server/https.go
@@ -200,12 +200,27 @@ func (s *server) Acquire(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	dev, err := s.bus.Connect(path)
-	if err != nil {
-		respondError(w, err)
-		return
+	// Chrome tries to read from Trezor immediately after connecting
+	// So do we
+	// Bad timing can produce error on s.bus.Connect
+	// => try 3 times with a 100ms delay
+	tries := 0
+	for {
+		dev, err := s.bus.Connect(path)
+		if err != nil {
+			if tries < 3 {
+				tries++
+				time.Sleep(100 * time.Millisecond)
+			} else {
+				respondError(w, err)
+				return
+			}
+		} else {
+			acquired.dev = dev
+			break
+		}
 	}
-	acquired.dev = dev
+
 	acquired.id = s.newSession()
 
 	s.sessions[acquired.id] = acquired


### PR DESCRIPTION
Because of how webUSB works, Google Chrome tries to read from the USB after connecting Trezor, to read metadata.

When the timing is wrong, it can happen that bridge is trying to open the device at the same time as Chrome. It's hard to replicate, but it happens once in a while.

To prevent throwing errors, it's better to try a few times before throwing out errors.